### PR TITLE
Validate location import data

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -225,6 +225,7 @@ return [
             'SimpleImportOrganizationExists' => Factory\Validator\OrganizationExistsFactory::class,
             Validator\CrawlerOptions::class => InvokableFactory::class,
             Validator\EntityExists::class => InvokableFactory::class,
+            Validator\IsString::class => InvokableFactory::class,
         ],
     ],
     'simple_import_crawler_processor_manager' => [

--- a/src/InputFilter/JobDataInputFilter.php
+++ b/src/InputFilter/JobDataInputFilter.php
@@ -11,6 +11,7 @@ namespace SimpleImport\InputFilter;
 use SimpleImport\Filter\MapClassificationsFilter;
 use Laminas\InputFilter\InputFilter;
 use Laminas\InputFilter\OptionalInputFilter;
+use SimpleImport\Validator\IsString;
 
 class JobDataInputFilter extends InputFilter
 {
@@ -41,7 +42,12 @@ class JobDataInputFilter extends InputFilter
                 [
                     'name' => 'StringTrim'
                 ]
-            ]
+            ],
+            'validators' => [
+                [
+                    'name' => IsString::class
+                ],
+            ],
         ])->add([
             'name' => 'company',
             'required' => false,

--- a/src/Validator/IsString.php
+++ b/src/Validator/IsString.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * YAWIK SimpleImport
+ *
+ * @copyright 2013-2020 Cross Solution
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace SimpleImport\Validator;
+
+use Laminas\Validator\AbstractValidator;
+
+/**
+ * TODO: description
+ *
+ * @author Mathias Gelhausen
+ * TODO: write tests
+ */
+class IsString extends AbstractValidator
+{
+    /**
+     * @var string
+     */
+    const NOT_STRING = 'notString';
+
+    /**
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_STRING => "Expected input to be of type string.",
+    ];
+
+    public function isValid($value)
+    {
+        if (is_string($value)) {
+            return true;
+        }
+
+        $this->error(self::NOT_STRING, $value);
+        return false;
+    }
+}

--- a/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
+++ b/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
@@ -195,5 +195,22 @@ class JobDataInputFilterTest extends TestCase
         $target->setData($data);
 
         static::assertFalse($target->isValid());
+        static::assertTrue(isset($target->getMessages()['location']['notString']), 'Missing error message');
+    }
+
+    public function testLocationIsValidIfString()
+    {
+        $target = new JobDataInputFilter([]);
+
+        $data = [
+            'id' => 'id',
+            'title' => 'title',
+            'link' => 'http://link.to/job',
+            'location' => 'finally a string',
+        ];
+
+        $target->setData($data);
+
+        static::assertTrue($target->isValid());
     }
 }

--- a/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
+++ b/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
@@ -174,4 +174,26 @@ class JobDataInputFilterTest extends TestCase
         $this->assertArrayHasKey('industries', $filtered, 'Filtered value should always contain known classifications');
         $this->assertSame($mappedExpected, $filtered['industries'], 'Filtered value should contain its passed value');
     }
+
+    /**
+     * @testWith    [true]
+     *              [1234]
+     *              [[1,2,3]]
+     *              [{"one":1, "two":2}]
+     */
+    public function testLocationIsInvalidIfNotString($location)
+    {
+        $target = new JobDataInputFilter([]);
+
+        $data = [
+            'id' => 'id',
+            'title' => 'title',
+            'link' => 'http://link.to/job',
+            'location' => $location
+        ];
+
+        $target->setData($data);
+
+        static::assertFalse($target->isValid());
+    }
 }

--- a/test/SimpleImportTest/Validator/IsStringTest.php
+++ b/test/SimpleImportTest/Validator/IsStringTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * YAWIK SimpleImport
+ *
+ * @see        for the canonical source repository
+ * @copyright /blob/master/COPYRIGHT
+ * @license   /blob/master/LICENSE MIT
+ */
+
+declare(strict_types=1);
+
+namespace SimpleImportTest\Validator;
+
+use Cross\TestUtils\TestCase\SetupTargetTrait;
+use Cross\TestUtils\TestCase\TestInheritanceTrait;
+use Laminas\Validator\AbstractValidator;
+use PHPUnit\Framework\TestCase;
+use SimpleImport\Validator\IsString;
+
+/**
+ * Testcase for \SimpleImport\Validator\IsString
+ *
+ * @covers \SimpleImport\Validator\IsString
+ * @author Mathias Gelhausen <gelhausen@cross-solution.de>
+ * @group
+ */
+class IsStringTest extends TestCase
+{
+    use TestInheritanceTrait, SetupTargetTrait;
+
+    private $target = IsString::class;
+
+    private $inheritance = [ AbstractValidator::class ];
+
+    public function testReturnsTrueIfValueIsString()
+    {
+        static::assertTrue($this->target->isValid('thisisastring'));
+    }
+
+    public function provideNotStringData()
+    {
+        return [
+            [true],
+            [1234],
+            [['an', 'array']],
+            'assoc' => [['one' => 1, 'two' => 2]],
+            [new \stdClass]
+        ];
+    }
+
+    /**
+     * @dataProvider provideNotStringData
+     */
+    public function testReturnsFalseIfValueIsNotString($value)
+    {
+        static::assertFalse($this->target->isValid($value));
+    }
+
+    public function testProducesErrorMessageOnFailure()
+    {
+        $expect = 'Expected input to be of type string.';
+
+        $this->target->isValid(false);
+        $messages = $this->target->getMessages();
+
+        static::assertIsArray($messages);
+        static::assertArrayHasKey(IsString::NOT_STRING, $messages);
+        static::assertEquals($expect, $messages[IsString::NOT_STRING]);
+    }
+}


### PR DESCRIPTION
The `location` field in the import data must be a string.

This pull request adds validation to ensure that the location is a string.