### PR TITLE
Fix: an emty array passes the location validation

### DIFF
--- a/src/InputFilter/JobDataInputFilter.php
+++ b/src/InputFilter/JobDataInputFilter.php
@@ -38,6 +38,7 @@ class JobDataInputFilter extends InputFilter
         ])->add([
             'name' => 'location',
             'required' => false,
+            'continue_if_empty' => true,
             'filters' => [
                 [
                     'name' => 'StringTrim'

--- a/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
+++ b/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
@@ -181,6 +181,9 @@ class JobDataInputFilterTest extends TestCase
      *              [[1,2,3]]
      *              [{"one":1, "two":2}]
      *              [[]]
+     *              [null]
+     *              [0]
+     *              [false]
      */
     public function testLocationIsInvalidIfNotString($location)
     {
@@ -199,7 +202,11 @@ class JobDataInputFilterTest extends TestCase
         static::assertTrue(isset($target->getMessages()['location']['notString']), 'Missing error message');
     }
 
-    public function testLocationIsValidIfString()
+    /**
+     * @testWith    ["finally a string"]
+     *              [""]
+     */
+    public function testLocationIsValidIfString($str)
     {
         $target = new JobDataInputFilter([]);
 
@@ -207,7 +214,7 @@ class JobDataInputFilterTest extends TestCase
             'id' => 'id',
             'title' => 'title',
             'link' => 'http://link.to/job',
-            'location' => 'finally a string',
+            'location' => $str,
         ];
 
         $target->setData($data);

--- a/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
+++ b/test/SimpleImportTest/InputFilter/JobDataInputFilterTest.php
@@ -180,6 +180,7 @@ class JobDataInputFilterTest extends TestCase
      *              [1234]
      *              [[1,2,3]]
      *              [{"one":1, "two":2}]
+     *              [[]]
      */
     public function testLocationIsInvalidIfNotString($location)
     {


### PR DESCRIPTION
The location must be a string, which is validated in the JobDataInputFilter.

However, passing an empty array validates and leads to an exception being thrown.